### PR TITLE
Patch small error in getPageRangeString-function

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -61,7 +61,7 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                     //TODO: Format these numbers, perhaps optionally
                     var maxOnPage = total !== $scope.filtering.filteredCount ? $scope.filtering.filteredCount : total;
                     //This keeps the first page labeled as 1, not 0
-                    var startPage = Math.max(($scope.pagination.currentPage - 1) * ($scope.pagination.perPage + 1), 1);
+                    var startPage = Math.max(($scope.pagination.currentPage - 1) * $scope.pagination.perPage + 1, 1);
                     var endPage = Math.min($scope.pagination.currentPage * $scope.pagination.perPage, maxOnPage);
                     //This prevents the range from showing when the total number of items can be shown on a single page
                     return $scope.filtering.filteredCount === 0 ? "" : (endPage === maxOnPage && startPage === 1 ? "" : startPage + "-") + endPage;


### PR DESCRIPTION
There were an error in which the function produces a wrong range.
for example, you are on page 7 and you got 100 Items and 10 Pages (10 Items per page):
**the old Code:**
($scope.pagination.currentPage - 1) \* ($scope.pagination.perPage + 1)
(7 - 1) \* (10 + 1)
6 \* 11
= 66 (you get "Showing **66-70** of 100 items", in this range are only 5 items)

**the new Code:**
($scope.pagination.currentPage - 1) \* $scope.pagination.perPage + 1
(7 - 1) \* 10 + 1
6 \* 10 + 1
= 61 (you get "Showing **61-70** of 100 items", in this range are the expected 10 items)
